### PR TITLE
bugfixes

### DIFF
--- a/dn3/trainable/processes.py
+++ b/dn3/trainable/processes.py
@@ -569,7 +569,7 @@ class BaseProcess(object):
                 if callable(step_callback):
                     step_callback(train_metrics)
 
-                if iteration % train_log_interval == 0 and pbar.total != iteration:
+                if iteration % train_log_interval == 0 and pbar.total >= iteration:
                     print_training_metrics(epoch, iteration)
                     train_metrics['epoch'] = epoch
                     train_metrics['iteration'] = iteration

--- a/dn3/utils.py
+++ b/dn3/utils.py
@@ -103,7 +103,6 @@ def make_epochs_from_raw(raw: mne.io.Raw, tmin, tlen, event_ids=None, baseline=N
             events = mne.events_from_annotations(raw, event_id=event_ids, chunk_duration=chunk_duration)[0]
         else:
             events = mne.find_events(raw)
-            events = events[[i for i in range(len(events)) if events[i, -1] in event_ids.keys()], :]
     except ValueError as e:
         raise DN3ConfigException(*e.args)
 


### PR DESCRIPTION
### 1
In the [processes.py](dn3/trainable/processes.py) file, line 572, when train_log_interval is not provided it is set to len(training_dataset). Hence, the first part of the if-test is only True if iteration is a multiple of len(training_dataset). 
However, pbar.total is also set to len(training_dataset) and thus the second test can never pass when iteration is equal to len(training_dataset), which is when the if-test should actually be succeeding. Should this not be:

`if iteration % train_log_interval == 0 and pbar.total >= iteration:`

Instead of:

`if iteration % train_log_interval == 0 and pbar.total != iteration:`

### 2
In the [utils.py](dn3/utils.py) file, line 106, when the dataset does not explicitly provide event ids, all event ids should be selected.
However, event_ids is set to None and therefore line 106 results in an AttributeError:

`events = events[[i for i in range(len(events)) if events[i, -1] in event_ids.keys()], :]`


