### PR TITLE
Fixed issue with epoch ID -> class label mapping.

### DIFF
--- a/dn3/configuratron/config.py
+++ b/dn3/configuratron/config.py
@@ -508,11 +508,12 @@ class DatasetConfig:
     @staticmethod
     def _prepare_session(raw, tlen, decimate, desired_sfreq, desired_samples, picks, exclude_channels, rename_channels,
                          hpf, lpf, notch_freq):
+        if notch_freq is not None:
+            raw.notch_filter(notch_freq)
         if hpf is not None or lpf is not None:
             raw = raw.filter(hpf, lpf)
         
-        if notch_freq is not None:
-            raw.notch_filter(notch_freq)
+        
 
         lowpass = raw.info.get('lowpass', None)
         raw_sfreq = raw.info['sfreq']

--- a/dn3/configuratron/config.py
+++ b/dn3/configuratron/config.py
@@ -232,8 +232,8 @@ class DatasetConfig:
         self.hpf = get_pop('hpf', None)
         self.lpf = get_pop('lpf', None)
         self.notch_freq = get_pop('notch_freq', None)
-        self.create_avg_ref = get_pop('create_avg_ref', False)
-        self.filter_data = self.hpf is not None or self.lpf is not None or self.notch_freq is not None or self.create_avg_ref
+        self.use_avg_ref = get_pop('use_avg_ref', False)
+        self.filter_data = self.hpf is not None or self.lpf is not None or self.notch_freq is not None or self.use_avg_ref
         if self.filter_data:
             self.preload = True
         self.stride = get_pop('stride', 1)
@@ -508,8 +508,8 @@ class DatasetConfig:
 
     @staticmethod
     def _prepare_session(raw, tlen, decimate, desired_sfreq, desired_samples, picks, exclude_channels, rename_channels,
-                         hpf, lpf, notch_freq, create_avg_ref):
-        if create_avg_ref:
+                         hpf, lpf, notch_freq, use_avg_ref):
+        if use_avg_ref:
             raw.set_eeg_reference(ref_channels='average')
         if notch_freq is not None:
             raw.notch_filter(notch_freq)
@@ -572,7 +572,7 @@ class DatasetConfig:
                 sess = Path(sess)
             r = self._load_raw(sess)
             return (sess, *self._prepare_session(r, self.tlen, self.decimate, self._sfreq, self._samples, self.picks,
-                                                self.exclude_channels, self.rename_channels, self.hpf, self.lpf, self.notch_freq, self.create_avg_ref))
+                                                self.exclude_channels, self.rename_channels, self.hpf, self.lpf, self.notch_freq, self.use_avg_ref))
         sess, raw, tlen, picks, new_sfreq = load_and_prepare(session)
 
         # Fixme - deprecate the decimate option in favour of specifying desired sfreq's

--- a/dn3/configuratron/config.py
+++ b/dn3/configuratron/config.py
@@ -231,7 +231,8 @@ class DatasetConfig:
         self.dumped = get_pop('pre-dumped')
         self.hpf = get_pop('hpf', None)
         self.lpf = get_pop('lpf', None)
-        self.filter_data = self.hpf is not None or self.lpf is not None
+        self.notch_freq = get_pop('notch_freq', None)
+        self.filter_data = self.hpf is not None or self.lpf is not None or self.notch_freq is not None
         if self.filter_data:
             self.preload = True
         self.stride = get_pop('stride', 1)
@@ -506,9 +507,12 @@ class DatasetConfig:
 
     @staticmethod
     def _prepare_session(raw, tlen, decimate, desired_sfreq, desired_samples, picks, exclude_channels, rename_channels,
-                         hpf, lpf):
+                         hpf, lpf, notch_freq):
         if hpf is not None or lpf is not None:
             raw = raw.filter(hpf, lpf)
+        
+        if notch_freq is not None:
+            raw.notch_filter(notch_freq)
 
         lowpass = raw.info.get('lowpass', None)
         raw_sfreq = raw.info['sfreq']
@@ -564,7 +568,7 @@ class DatasetConfig:
                 sess = Path(sess)
             r = self._load_raw(sess)
             return (sess, *self._prepare_session(r, self.tlen, self.decimate, self._sfreq, self._samples, self.picks,
-                                                self.exclude_channels, self.rename_channels, self.hpf, self.lpf))
+                                                self.exclude_channels, self.rename_channels, self.hpf, self.lpf, self.notch_freq))
         sess, raw, tlen, picks, new_sfreq = load_and_prepare(session)
 
         # Fixme - deprecate the decimate option in favour of specifying desired sfreq's

--- a/dn3/configuratron/config.py
+++ b/dn3/configuratron/config.py
@@ -232,7 +232,8 @@ class DatasetConfig:
         self.hpf = get_pop('hpf', None)
         self.lpf = get_pop('lpf', None)
         self.notch_freq = get_pop('notch_freq', None)
-        self.filter_data = self.hpf is not None or self.lpf is not None or self.notch_freq is not None
+        self.create_avg_ref = get_pop('create_avg_ref', False)
+        self.filter_data = self.hpf is not None or self.lpf is not None or self.notch_freq is not None or self.create_avg_ref
         if self.filter_data:
             self.preload = True
         self.stride = get_pop('stride', 1)
@@ -507,7 +508,9 @@ class DatasetConfig:
 
     @staticmethod
     def _prepare_session(raw, tlen, decimate, desired_sfreq, desired_samples, picks, exclude_channels, rename_channels,
-                         hpf, lpf, notch_freq):
+                         hpf, lpf, notch_freq, create_avg_ref):
+        if create_avg_ref:
+            raw.set_eeg_reference(ref_channels='average')
         if notch_freq is not None:
             raw.notch_filter(notch_freq)
         if hpf is not None or lpf is not None:
@@ -569,7 +572,7 @@ class DatasetConfig:
                 sess = Path(sess)
             r = self._load_raw(sess)
             return (sess, *self._prepare_session(r, self.tlen, self.decimate, self._sfreq, self._samples, self.picks,
-                                                self.exclude_channels, self.rename_channels, self.hpf, self.lpf, self.notch_freq))
+                                                self.exclude_channels, self.rename_channels, self.hpf, self.lpf, self.notch_freq, self.create_avg_ref))
         sess, raw, tlen, picks, new_sfreq = load_and_prepare(session)
 
         # Fixme - deprecate the decimate option in favour of specifying desired sfreq's

--- a/dn3/data/dataset.py
+++ b/dn3/data/dataset.py
@@ -381,7 +381,7 @@ class EpochTorchRecording(_Recording):
             self.epoch_codes_to_class_labels = event_mapping
         else:
             reverse_mapping = {v: k for k, v in event_mapping.items()}
-            self.epoch_codes_to_class_labels = {v: i for i, v in enumerate(sorted(reverse_mapping.keys()))}
+            self.epoch_codes_to_class_labels = {v: i for i, v in enumerate(sorted(reverse_mapping.values()))}
         skip_epochs = list() if skip_epochs is None else skip_epochs
         self._skip_map = [i for i in range(len(self.epochs.events)) if i not in skip_epochs]
         self._skip_map = dict(zip(range(len(self._skip_map)), self._skip_map))

--- a/dn3/trainable/models.py
+++ b/dn3/trainable/models.py
@@ -425,6 +425,6 @@ class BENDRClassifier(Classifier):
     def features_forward(self, x):
         x = self.encoder(x)
         x = self.contextualizer(x)
-        return x[0]
+        return x[:, :, 0]
 
 

--- a/dn3/trainable/processes.py
+++ b/dn3/trainable/processes.py
@@ -569,7 +569,7 @@ class BaseProcess(object):
                 if callable(step_callback):
                     step_callback(train_metrics)
 
-                if iteration % train_log_interval == 0 and pbar.total != iteration:
+                if iteration % train_log_interval == 0 and pbar.total >= iteration:
                     print_training_metrics(epoch, iteration)
                     train_metrics['epoch'] = epoch
                     train_metrics['iteration'] = iteration

--- a/tests/testTrainables.py
+++ b/tests/testTrainables.py
@@ -6,7 +6,7 @@ import sys
 
 from torch.utils.data import DataLoader
 from dn3.trainable.processes import StandardClassification
-from dn3.trainable.models import EEGNetStrided
+from dn3.trainable.models import *
 from dn3.metrics.base import balanced_accuracy
 from tests.dummy_data import create_dummy_dataset, retrieve_underlying_dummy_data, EVENTS
 
@@ -88,6 +88,32 @@ class TestSimpleClassifier(unittest.TestCase):
         val_metrics = trainable.evaluate(self.dataset)
         self.assertIn('BAC', val_metrics)
         self.assertIn('loss', val_metrics)
+
+class TestIncludedModels(unittest.TestCase):
+
+    _BATCH_SIZES = [1, 2, 4, 8, 11]
+
+    def setUp(self) -> None:
+        mne.set_log_level(False)
+        self.dataset = create_dummy_dataset()
+
+    def test_TIDNet(self):
+        model = TIDNet.from_dataset(self.dataset)
+        process = StandardClassification(model)
+
+        for bs in self._BATCH_SIZES:
+            with self.subTest(batch_size=bs):
+                process.predict(self.dataset, batch_size=bs)
+                self.assertTrue(True)
+
+    def test_BENDRClassifier(self):
+        model = BENDRClassifier.from_dataset(self.dataset)
+        process = StandardClassification(model)
+
+        for bs in self._BATCH_SIZES:
+            with self.subTest(batch_size=bs):
+                process.predict(self.dataset, batch_size=bs)
+                self.assertTrue(True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If you specify events with names mapping to IDs, dn3 incorrectly maps the event name (string) to the classifier label, this fails with a `KeyError` like:

```
  File "C:\tools\miniconda3\envs\eegtorch\lib\site-packages\dn3\data\dataset.py", line 433, in <lambda>
    return np.apply_along_axis(lambda x: self.epoch_codes_to_class_labels[x[0]], 1,
KeyError: 108
```

The data in this case is stored in MNE fif files, and contains a stim channel with `int` markers which track a single sample where the stimuli was presented, I also tried using event IDs as a list without a name string, but the issue was the same.

this PR maintains the mapping but uses the value rather than the key for the mapping.

Sample config yaml:

```yaml
Configuratron:
  sfreq: 100
  preload: True
  deep1010: True
  preload: True
  architecture:
    layers: 16
    activation: 'relu'
    dropout: 0.1
use_gpu: True
test_fraction: 0.2
datasets:
  clencher:
    dataset_id: 1
    name: "CogSci clencher"
    toplevel: "./data_nn/"
    filename_format: "grasp_{subject}_{session}_raw"
    tmin: -0.1
    tlen: 4.0
    data_min: True
    data_max: True
    hpf: 0.1
    lpf: 49
    events:
      108: "l"
      110: "n"
    picks:
      - C3
      - P3
    lr: 0.00001
    train_params:
      folds: 3
    training_configuration:
      batch_size: 8
      epochs: 100
```