### PR TITLE
Fixed issue with epoch ID -> class label mapping. [correct branch from forked repo]

### DIFF
--- a/dn3/data/dataset.py
+++ b/dn3/data/dataset.py
@@ -381,7 +381,7 @@ class EpochTorchRecording(_Recording):
             self.epoch_codes_to_class_labels = event_mapping
         else:
             reverse_mapping = {v: k for k, v in event_mapping.items()}
-            self.epoch_codes_to_class_labels = {v: i for i, v in enumerate(sorted(reverse_mapping.keys()))}
+            self.epoch_codes_to_class_labels = {v: i for i, v in enumerate(sorted(reverse_mapping.values()))}
         skip_epochs = list() if skip_epochs is None else skip_epochs
         self._skip_map = [i for i in range(len(self.epochs.events)) if i not in skip_epochs]
         self._skip_map = dict(zip(range(len(self._skip_map)), self._skip_map))


### PR DESCRIPTION
If you specify events with names mapping to IDs, dn3 incorrectly maps the event name (string) to the classifier label, this fails with a `KeyError` like:

```
  File "C:\tools\miniconda3\envs\eegtorch\lib\site-packages\dn3\data\dataset.py", line 433, in <lambda>
    return np.apply_along_axis(lambda x: self.epoch_codes_to_class_labels[x[0]], 1,
KeyError: 108
```

The data in this case is stored in MNE fif files, and contains a stim channel with `int` markers which track a single sample where the stimuli was presented, I also tried using event IDs as a list without a name string, but the issue was the same.

this PR maintains the mapping but uses the value rather than the key for the mapping.

Sample config yaml:

```yaml
Configuratron:
  sfreq: 100
  preload: True
  deep1010: True
  preload: True
  architecture:
    layers: 16
    activation: 'relu'
    dropout: 0.1
use_gpu: True
test_fraction: 0.2
datasets:
  clencher:
    dataset_id: 1
    name: "CogSci clencher"
    toplevel: "./data_nn/"
    filename_format: "grasp_{subject}_{session}_raw"
    tmin: -0.1
    tlen: 4.0
    data_min: True
    data_max: True
    hpf: 0.1
    lpf: 49
    events:
      108: "l"
      110: "n"
    picks:
      - C3
      - P3
    lr: 0.00001
    train_params:
      folds: 3
    training_configuration:
      batch_size: 8
      epochs: 100
```