### PR TITLE
Bugfix/rand split torch data

### DIFF
--- a/dn3/configuratron/config.py
+++ b/dn3/configuratron/config.py
@@ -508,11 +508,12 @@ class DatasetConfig:
     @staticmethod
     def _prepare_session(raw, tlen, decimate, desired_sfreq, desired_samples, picks, exclude_channels, rename_channels,
                          hpf, lpf, notch_freq):
+        if notch_freq is not None:
+            raw.notch_filter(notch_freq)
         if hpf is not None or lpf is not None:
             raw = raw.filter(hpf, lpf)
         
-        if notch_freq is not None:
-            raw.notch_filter(notch_freq)
+        
 
         lowpass = raw.info.get('lowpass', None)
         raw_sfreq = raw.info['sfreq']

--- a/dn3/configuratron/config.py
+++ b/dn3/configuratron/config.py
@@ -232,8 +232,8 @@ class DatasetConfig:
         self.hpf = get_pop('hpf', None)
         self.lpf = get_pop('lpf', None)
         self.notch_freq = get_pop('notch_freq', None)
-        self.create_avg_ref = get_pop('create_avg_ref', False)
-        self.filter_data = self.hpf is not None or self.lpf is not None or self.notch_freq is not None or self.create_avg_ref
+        self.use_avg_ref = get_pop('use_avg_ref', False)
+        self.filter_data = self.hpf is not None or self.lpf is not None or self.notch_freq is not None or self.use_avg_ref
         if self.filter_data:
             self.preload = True
         self.stride = get_pop('stride', 1)
@@ -508,8 +508,8 @@ class DatasetConfig:
 
     @staticmethod
     def _prepare_session(raw, tlen, decimate, desired_sfreq, desired_samples, picks, exclude_channels, rename_channels,
-                         hpf, lpf, notch_freq, create_avg_ref):
-        if create_avg_ref:
+                         hpf, lpf, notch_freq, use_avg_ref):
+        if use_avg_ref:
             raw.set_eeg_reference(ref_channels='average')
         if notch_freq is not None:
             raw.notch_filter(notch_freq)
@@ -572,7 +572,7 @@ class DatasetConfig:
                 sess = Path(sess)
             r = self._load_raw(sess)
             return (sess, *self._prepare_session(r, self.tlen, self.decimate, self._sfreq, self._samples, self.picks,
-                                                self.exclude_channels, self.rename_channels, self.hpf, self.lpf, self.notch_freq, self.create_avg_ref))
+                                                self.exclude_channels, self.rename_channels, self.hpf, self.lpf, self.notch_freq, self.use_avg_ref))
         sess, raw, tlen, picks, new_sfreq = load_and_prepare(session)
 
         # Fixme - deprecate the decimate option in favour of specifying desired sfreq's

--- a/dn3/configuratron/config.py
+++ b/dn3/configuratron/config.py
@@ -231,7 +231,8 @@ class DatasetConfig:
         self.dumped = get_pop('pre-dumped')
         self.hpf = get_pop('hpf', None)
         self.lpf = get_pop('lpf', None)
-        self.filter_data = self.hpf is not None or self.lpf is not None
+        self.notch_freq = get_pop('notch_freq', None)
+        self.filter_data = self.hpf is not None or self.lpf is not None or self.notch_freq is not None
         if self.filter_data:
             self.preload = True
         self.stride = get_pop('stride', 1)
@@ -506,9 +507,12 @@ class DatasetConfig:
 
     @staticmethod
     def _prepare_session(raw, tlen, decimate, desired_sfreq, desired_samples, picks, exclude_channels, rename_channels,
-                         hpf, lpf):
+                         hpf, lpf, notch_freq):
         if hpf is not None or lpf is not None:
             raw = raw.filter(hpf, lpf)
+        
+        if notch_freq is not None:
+            raw.notch_filter(notch_freq)
 
         lowpass = raw.info.get('lowpass', None)
         raw_sfreq = raw.info['sfreq']
@@ -564,7 +568,7 @@ class DatasetConfig:
                 sess = Path(sess)
             r = self._load_raw(sess)
             return (sess, *self._prepare_session(r, self.tlen, self.decimate, self._sfreq, self._samples, self.picks,
-                                                self.exclude_channels, self.rename_channels, self.hpf, self.lpf))
+                                                self.exclude_channels, self.rename_channels, self.hpf, self.lpf, self.notch_freq))
         sess, raw, tlen, picks, new_sfreq = load_and_prepare(session)
 
         # Fixme - deprecate the decimate option in favour of specifying desired sfreq's

--- a/dn3/configuratron/config.py
+++ b/dn3/configuratron/config.py
@@ -467,7 +467,7 @@ class DatasetConfig:
         Parameters
         ----------
         custom_loader: callable
-                       A function that expects a single :any:`pathlib.Path()` instance as argument and returns an
+                       A function that expects a :any:`DatasetConfig` :any:`pathlib.Path()` instance as argument and returns an
                        instance of :any:`mne.io.Raw()`. To gracefully ignore problematic sessions, raise
                        :any:`DN3ConfigException` within.
 
@@ -495,7 +495,7 @@ class DatasetConfig:
 
     def _load_raw(self, path: Path):
         if self._custom_raw_loader is not None:
-            return self._custom_raw_loader(path)
+            return self._custom_raw_loader(self, path)
         if path.suffix in self._extension_handlers:
             return self._extension_handlers[path.suffix](str(path), preload=self.preload)
         print("Handler for file {} with extension {} not found.".format(str(path), path.suffix))

--- a/dn3/configuratron/config.py
+++ b/dn3/configuratron/config.py
@@ -232,7 +232,8 @@ class DatasetConfig:
         self.hpf = get_pop('hpf', None)
         self.lpf = get_pop('lpf', None)
         self.notch_freq = get_pop('notch_freq', None)
-        self.filter_data = self.hpf is not None or self.lpf is not None or self.notch_freq is not None
+        self.create_avg_ref = get_pop('create_avg_ref', False)
+        self.filter_data = self.hpf is not None or self.lpf is not None or self.notch_freq is not None or self.create_avg_ref
         if self.filter_data:
             self.preload = True
         self.stride = get_pop('stride', 1)
@@ -507,7 +508,9 @@ class DatasetConfig:
 
     @staticmethod
     def _prepare_session(raw, tlen, decimate, desired_sfreq, desired_samples, picks, exclude_channels, rename_channels,
-                         hpf, lpf, notch_freq):
+                         hpf, lpf, notch_freq, create_avg_ref):
+        if create_avg_ref:
+            raw.set_eeg_reference(ref_channels='average')
         if notch_freq is not None:
             raw.notch_filter(notch_freq)
         if hpf is not None or lpf is not None:
@@ -569,7 +572,7 @@ class DatasetConfig:
                 sess = Path(sess)
             r = self._load_raw(sess)
             return (sess, *self._prepare_session(r, self.tlen, self.decimate, self._sfreq, self._samples, self.picks,
-                                                self.exclude_channels, self.rename_channels, self.hpf, self.lpf, self.notch_freq))
+                                                self.exclude_channels, self.rename_channels, self.hpf, self.lpf, self.notch_freq, self.create_avg_ref))
         sess, raw, tlen, picks, new_sfreq = load_and_prepare(session)
 
         # Fixme - deprecate the decimate option in favour of specifying desired sfreq's

--- a/dn3/data/dataset.py
+++ b/dn3/data/dataset.py
@@ -182,48 +182,6 @@ class DN3ataset(TorchDataset):
                 loaded = [np.concatenate([loaded[i], batch[i]], axis=0) for i in range(len(batch))]
 
         return loaded
-
-<<<<<<< Updated upstream
-class DN3Subset(DN3ataset, TorchSubset):
-    
-        def __init__(self, dataset, indices):
-            super().__init__()
-            self.dataset = dataset
-            self.indices = indices
-    
-        def __getitem__(self, idx):
-            return TorchSubset.__getitem__(self, idx)
-    
-        def __len__(self):
-            return TorchSubset.__len__(self)
-        
-        @staticmethod
-        def init_from_torch_subset(subset: TorchSubset):
-            return DN3Subset(subset.dataset, subset.indices)
-    
-        @property
-        def sfreq(self):
-            return self.dataset.sfreq
-    
-        @property
-        def channels(self):
-            return self.dataset.channels
-    
-        @property
-        def sequence_length(self):
-            return self.dataset.sequence_length
-    
-        def clone(self):
-            return DN3Subset(self.dataset, self.indices)
-    
-        def preprocess(self, preprocessor: Preprocessor, apply_transform=True):
-            return self.dataset.preprocess(preprocessor, apply_transform)
-    
-        def to_numpy(self, batch_size=64, batch_transforms: list = None, num_workers=4, **dataloader_kwargs):
-            return self.dataset.to_numpy(batch_size, batch_transforms, num_workers, **dataloader_kwargs)
-
-=======
->>>>>>> Stashed changes
 class _Recording(DN3ataset, ABC):
     """
     Abstract base class for any supported recording

--- a/dn3/data/dataset.py
+++ b/dn3/data/dataset.py
@@ -381,7 +381,7 @@ class EpochTorchRecording(_Recording):
             self.epoch_codes_to_class_labels = event_mapping
         else:
             reverse_mapping = {v: k for k, v in event_mapping.items()}
-            self.epoch_codes_to_class_labels = {v: i for i, v in enumerate(sorted(reverse_mapping.keys()))}
+            self.epoch_codes_to_class_labels = {v: i for i, v in enumerate(sorted(reverse_mapping.values()))}
         skip_epochs = list() if skip_epochs is None else skip_epochs
         self._skip_map = [i for i in range(len(self.epochs.events)) if i not in skip_epochs]
         self._skip_map = dict(zip(range(len(self._skip_map)), self._skip_map))

--- a/dn3/trainable/models.py
+++ b/dn3/trainable/models.py
@@ -425,6 +425,6 @@ class BENDRClassifier(Classifier):
     def features_forward(self, x):
         x = self.encoder(x)
         x = self.contextualizer(x)
-        return x[0]
+        return x[:, :, 0]
 
 

--- a/dn3/trainable/models.py
+++ b/dn3/trainable/models.py
@@ -185,7 +185,7 @@ class Classifier(DN3BaseModel):
 
 class StrideClassifier(Classifier, metaclass=ABCMeta):
 
-    def __init__(self, targets, samples, channels, stride_width=2, return_features=False):
+    def __init__(self, targets, samples, channels, stride_width=2, return_features=False, bias_output=False):
         """
         Instead of summarizing the entire temporal dimension into a single prediction, a prediction kernel is swept over
         the final sequence representation and generates predictions at each step.
@@ -199,13 +199,15 @@ class StrideClassifier(Classifier, metaclass=ABCMeta):
         return_features
         """
         self.stride_width = stride_width
+        self.biased_output = bias_output
         super(StrideClassifier, self).__init__(targets, samples, channels, return_features=return_features)
 
     def make_new_classification_layer(self):
         self.classifier = torch.nn.Conv1d(self.num_features_for_classification, self.targets,
-                                          kernel_size=self.stride_width)
+                                          kernel_size=self.stride_width, bias=self.biased_output)
         torch.nn.init.xavier_normal_(self.classifier.weight)
-        self.classifier.bias.data.zero_()
+        if self.biased_output:
+            self.classifier.bias.data.zero_()
 
 
 class LogRegNetwork(Classifier):

--- a/dn3/trainable/processes.py
+++ b/dn3/trainable/processes.py
@@ -569,7 +569,7 @@ class BaseProcess(object):
                 if callable(step_callback):
                     step_callback(train_metrics)
 
-                if iteration % train_log_interval == 0 and pbar.total != iteration:
+                if iteration % train_log_interval == 0 and pbar.total >= iteration:
                     print_training_metrics(epoch, iteration)
                     train_metrics['epoch'] = epoch
                     train_metrics['iteration'] = iteration

--- a/dn3/utils.py
+++ b/dn3/utils.py
@@ -52,7 +52,6 @@ class DN3atasetNanFound(BaseException):
 def rand_split(dataset, frac=0.75):
     if frac >= 1:
         return dataset
-    print("type of dataset is {}".format(type(dataset)))
     samples = len(dataset)
 
     return random_split(dataset, lengths=[round(x) for x in [samples*frac, samples*(1-frac)]])

--- a/dn3/utils.py
+++ b/dn3/utils.py
@@ -52,7 +52,9 @@ class DN3atasetNanFound(BaseException):
 def rand_split(dataset, frac=0.75):
     if frac >= 1:
         return dataset
+    print("type of dataset is {}".format(type(dataset)))
     samples = len(dataset)
+
     return random_split(dataset, lengths=[round(x) for x in [samples*frac, samples*(1-frac)]])
 
 

--- a/dn3/utils.py
+++ b/dn3/utils.py
@@ -53,7 +53,6 @@ def rand_split(dataset, frac=0.75):
     if frac >= 1:
         return dataset
     samples = len(dataset)
-    # @TODO: return DN3ataset wrapped torch.utils.data.dataset.Subset
     return random_split(dataset, lengths=[round(x) for x in [samples*frac, samples*(1-frac)]])
 
 

--- a/dn3/utils.py
+++ b/dn3/utils.py
@@ -53,6 +53,7 @@ def rand_split(dataset, frac=0.75):
     if frac >= 1:
         return dataset
     samples = len(dataset)
+    # @TODO: return DN3ataset wrapped torch.utils.data.dataset.Subset
     return random_split(dataset, lengths=[round(x) for x in [samples*frac, samples*(1-frac)]])
 
 

--- a/tests/testTrainables.py
+++ b/tests/testTrainables.py
@@ -6,7 +6,7 @@ import sys
 
 from torch.utils.data import DataLoader
 from dn3.trainable.processes import StandardClassification
-from dn3.trainable.models import EEGNetStrided
+from dn3.trainable.models import *
 from dn3.metrics.base import balanced_accuracy
 from tests.dummy_data import create_dummy_dataset, retrieve_underlying_dummy_data, EVENTS
 
@@ -88,6 +88,32 @@ class TestSimpleClassifier(unittest.TestCase):
         val_metrics = trainable.evaluate(self.dataset)
         self.assertIn('BAC', val_metrics)
         self.assertIn('loss', val_metrics)
+
+class TestIncludedModels(unittest.TestCase):
+
+    _BATCH_SIZES = [1, 2, 4, 8, 11]
+
+    def setUp(self) -> None:
+        mne.set_log_level(False)
+        self.dataset = create_dummy_dataset()
+
+    def test_TIDNet(self):
+        model = TIDNet.from_dataset(self.dataset)
+        process = StandardClassification(model)
+
+        for bs in self._BATCH_SIZES:
+            with self.subTest(batch_size=bs):
+                process.predict(self.dataset, batch_size=bs)
+                self.assertTrue(True)
+
+    def test_BENDRClassifier(self):
+        model = BENDRClassifier.from_dataset(self.dataset)
+        process = StandardClassification(model)
+
+        for bs in self._BATCH_SIZES:
+            with self.subTest(batch_size=bs):
+                process.predict(self.dataset, batch_size=bs)
+                self.assertTrue(True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I'm using the OpenBCI cyton/daisy setup, and it doesn't have EOG channels setup by default, also we're not working with huge data sets so we want to concatenate the data from one  participant but split it into sets. As such this PR is to:

- Added MNE related options to conf
  - notch filtering
  - adding an average ref channel
- merge PR #75 and #76
- Fix `Thinker.split()` returning unwrapped `torch.utils.data.dataset.Subset` instead returning a new `DN3ataSubSet` object which wrapps Subset and includes a `get_targets` method to allow using the returned `training`, `validating` and `testing` variables inside a  `BaseProcess.fit` method with a `balance_method` argument
